### PR TITLE
reset report textbox after successful submission

### DIFF
--- a/frontend/src/pages/Admin/components/CreateReportFormDialog.tsx
+++ b/frontend/src/pages/Admin/components/CreateReportFormDialog.tsx
@@ -42,11 +42,14 @@ export const CreateReportFormDialog = ({
     register,
     formState: { errors },
     handleSubmit,
+    resetField,
   } = useForm({
     resolver: yupResolver(schema),
   });
 
   const onSubmit = async (data) => {
+    console.log(isReportSuccess);
+
     data.postId = postId;
 
     reportPostApi(data);
@@ -57,7 +60,7 @@ export const CreateReportFormDialog = ({
     if (reportError) {
       if (!("status" in reportError)) {
         setServerMessage(
-          reportError.message ?? t("errors.unknown_server_error")
+          reportError.message ?? t("errors.unknown_server_error"),
         );
         return;
       }
@@ -68,19 +71,27 @@ export const CreateReportFormDialog = ({
         const errorMessages = err.errors.map(
           (error) =>
             `${error.msg}: ${error.location}.${error.path} = ${JSON.stringify(
-              error.value
-            )}`
+              error.value,
+            )}`,
         );
         setServerMessage(errorMessages.join(","));
       } else {
         err.errors.length > 0
           ? setServerMessage(
-              err.errors.join(",") ?? t("errors.unknown_server_error")
+              err.errors.join(",") ?? t("errors.unknown_server_error"),
             )
           : setServerMessage(err.message ?? t("errors.unknown_server_error"));
       }
     }
   }, [reportError]);
+
+  useEffect(() => {
+    if (!isReportSuccess) return;
+
+    console.log(isReportSuccess);
+
+    resetField(`notes`);
+  }, [isReportSuccess]);
 
   return (
     <Dialog open={open} onOpenChange={setOpen}>

--- a/frontend/src/pages/Admin/components/CreateReportFormDialog.tsx
+++ b/frontend/src/pages/Admin/components/CreateReportFormDialog.tsx
@@ -48,8 +48,6 @@ export const CreateReportFormDialog = ({
   });
 
   const onSubmit = async (data) => {
-    console.log(isReportSuccess);
-
     data.postId = postId;
 
     reportPostApi(data);
@@ -87,8 +85,6 @@ export const CreateReportFormDialog = ({
 
   useEffect(() => {
     if (!isReportSuccess) return;
-
-    console.log(isReportSuccess);
 
     resetField(`notes`);
   }, [isReportSuccess]);


### PR DESCRIPTION
simple change made to clear the textbox in the "report post" modal after the report is created successfully