### PR TITLE
#86: allow organization name as display name for organization users

### DIFF
--- a/frontend/src/pages/Account/components/UpdateUserInfoForm.tsx
+++ b/frontend/src/pages/Account/components/UpdateUserInfoForm.tsx
@@ -9,6 +9,7 @@ import { useGetSessionQuery, useUpdateUserMutation } from "@services/api";
 import { useEffect, useState } from "react";
 import { useForm } from "react-hook-form";
 import { updateUserInfoSchema } from "./schemas/UpdateUserInfoSchema";
+import { UserRole } from "@constants";
 
 const Heading = (text: string) => {
   return (
@@ -100,7 +101,9 @@ export const UpdateUserInfoForm = () => {
             <Label htmlFor="displayName">Display name</Label>
             <div className="mt-2">
               <Input
-                {...register("displayName")}
+                {...register("displayName", {
+                  disabled: session?.role.includes(UserRole.ORGANIZATION),
+                })}
                 type="text"
                 name="displayName"
                 id="displayName"

--- a/frontend/src/pages/Register/components/OrganizationRegistrationForm.tsx
+++ b/frontend/src/pages/Register/components/OrganizationRegistrationForm.tsx
@@ -37,6 +37,7 @@ export const OrganizationRegistrationForm = () => {
   const onSubmit = (data) => {
     data = {
       ...data,
+      displayName: data.organization, // Display name will be the same as organization by default
       type: UserDiscriminator.ORGANIZATION,
     };
     registerApi(data);
@@ -111,20 +112,6 @@ export const OrganizationRegistrationForm = () => {
             placeholder="Username"
             errorMessage={errors.username?.message}
           ></Input>
-        </div>
-      </div>
-
-      <div>
-        <Label htmlFor="displayName">Display name</Label>
-        <div className="mt-2">
-          <Input
-            {...register("displayName")}
-            id="displayName"
-            type="text"
-            autoComplete="nickname"
-            placeholder="Display name"
-            errorMessage={errors.displayName?.message}
-          />
         </div>
       </div>
 

--- a/frontend/src/pages/Register/components/OrganizationRegistrationForm.tsx
+++ b/frontend/src/pages/Register/components/OrganizationRegistrationForm.tsx
@@ -1,5 +1,7 @@
 import { Alert } from "@components";
-import { Button, Input, Label } from "@components/Controls";
+import { Button, Input, Label, Tooltip } from "@components/Controls";
+import { faInfoCircle } from "@fortawesome/free-solid-svg-icons";
+import { FontAwesomeIcon } from "@fortawesome/react-fontawesome";
 import { PlaceAutocomplete } from "@components/Controls/PlaceAutocomplete";
 import { SelectInput } from "@components/Controls/Select";
 import { UserDiscriminator } from "@constants";
@@ -174,8 +176,22 @@ export const OrganizationRegistrationForm = () => {
         </div>
       </div>
 
-      <div>
-        <Label htmlFor="organization">Organization</Label>
+      <div className="col-span-full">
+        <Label htmlFor="organization">
+          <span className="mr-2">Organization</span>
+          <Tooltip
+            asChild
+            message={
+              "This will be used as the display name i.e. must have only letters, numbers and symbols(-_.)."
+            }
+          >
+            <FontAwesomeIcon
+              tabIndex={0}
+              className=" text-gray-6400"
+              icon={faInfoCircle}
+            />
+          </Tooltip>
+        </Label>
         <div className="mt-2">
           <Input
             {...register("organization")}

--- a/frontend/src/pages/Register/components/schemas/RegisterOrganizationSchema.ts
+++ b/frontend/src/pages/Register/components/schemas/RegisterOrganizationSchema.ts
@@ -4,15 +4,6 @@ import YupPassword from "yup-password";
 YupPassword(yup); // ! extend yup for password validation
 
 export const registerOrganizationSchema = yup.object().shape({
-  displayName: yup
-    .string()
-    .min(3, "Must be 3 characters or more")
-    .max(32, "Must be less than 32 characters")
-    .matches(
-      /^[0-9a-zA-ZÀ-ÖØ-öø-ÿ-_.]+$/,
-      "Must contain only letters, numbers, and symbols(-_.)"
-    )
-    .required("Display name is required"),
   username: yup
     .string()
     .min(3, "Must be 3 characters or more")
@@ -41,7 +32,7 @@ export const registerOrganizationSchema = yup.object().shape({
     .max(32, "Must be less than 32 characters")
     .matches(
       /^[a-zA-ZÀ-ÖØ-öø-ÿ-' ]+$/,
-      "Must contain only letters and symbols (-')"
+      "Must contain only letters and symbols (-')",
     )
     .required("First name is required"),
   lastName: yup
@@ -50,26 +41,31 @@ export const registerOrganizationSchema = yup.object().shape({
     .max(32, "Must be less than 32 characters")
     .matches(
       /^[a-zA-ZÀ-ÖØ-öø-ÿ-' ]+$/,
-      "Must contain only letters and symbols (-')"
+      "Must contain only letters and symbols (-')",
     )
     .required("Last name is required"),
   phone: yup
     .string()
     .matches(
       /^\(?([0-9]{3})\)?[-. ]?([0-9]{3})[-. ]?([0-9]{4})$/,
-      (obj) => `${obj.value} is not a valid phone number`
+      (obj) => `${obj.value} is not a valid phone number`,
     )
     .required("Phone is required"),
   organization: yup
     .string()
     .min(3, "Must be 3 characters or more")
+    .max(32, "Must be less than 32 characters")
+    .matches(
+      /^[0-9a-zA-ZÀ-ÖØ-öø-ÿ-_.]+$/,
+      "Must contain only letters, numbers, and symbols(-_.)",
+    )
     .required("Organization is required"),
   streetAddress: yup.string().required("Address is required"),
   postalCode: yup
     .string()
     .matches(
       /^[A-Za-z]\d[A-Za-z][ -]?\d[A-Za-z]\d$/,
-      (obj) => `${obj.value} is not a valid postal code`
+      (obj) => `${obj.value} is not a valid postal code`,
     )
     .required("Postal code is required"),
   city: yup


### PR DESCRIPTION
Removed the input for display name from organization registration form + set display name as organization automatically
Disabled display name input on account settings page if role is ORGANIZATION